### PR TITLE
Migrate to Jackson 3.x; add compare() ops and Monte-Carlo Arcsin stre…

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,11 @@ for (long i = 0; i < totalPoints; i++) {
 See the full runnable version in `io.compprov.examples.pi.PiCalculator` (`calculate()`), and
 the side-by-side benchmark in `io.compprov.examples.pi.PiCalculationStress`.
 
+The same folding pattern also handles integrands where rejection sampling doesn't apply — see
+`io.compprov.examples.pi.MonteCarloArcsineIntegrationStress`, which estimates `pi` via the
+average-value method on `f(x) = 1/sqrt(1-x^2)` (unbounded as `x -> 1`, so no finite bounding box
+exists for rejection sampling).
+
 ### Concurrency
 
 `WrappedSubgraph` exposes two ways to invoke the folded template, trading memory for
@@ -266,7 +271,9 @@ parallelism:
 - **`executeConcurrent(args, resultDescriptor)`** allocates a fresh `MutableState` — a full copy
   of the template's intermediate variables — for every call, so independent invocations never
   contend on shared state and can run truly in parallel. The tradeoff is one extra
-  allocation-and-copy per call.
+  allocation-and-copy per call. See `io.compprov.examples.pi.MonteCarloArcsineIntegrationStressParallel`
+  for a driving loop that submits samples to an `ExecutorService` and calls `executeConcurrent()`
+  from multiple threads.
 
 ### Reproducing intermediate steps
 
@@ -450,6 +457,9 @@ If you use a custom type frequently, extend `DefaultComputationContext` to add a
 
 If custom type requires custom JSON serialization or deserialization, register a
 Jackson serializer/deserializer with the `ObjectMapper` inside your custom `ComputationEnvironment`.
+compprov-core runs on **Jackson 3.x** (`tools.jackson.*`), so custom deserializers implement
+`tools.jackson.databind.deser.std.StdDeserializer` / `ValueDeserializer`, not the Jackson 2.x
+`com.fasterxml.jackson.databind.JsonDeserializer`.
 See `DefaultComputationEnvironment` for examples using `ZonedDateTimeSerializer` and
 `MathContextDeserializer`, and `AmountDeserializer` for a custom-type example registered via
 `environment.registerWrapper(Amount.class, new AmountWrapper(), new AmountDeserializer())`.

--- a/pom.xml
+++ b/pom.xml
@@ -42,19 +42,27 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <junit.version>5.11.4</junit.version>
+        <junit.version>6.1.1</junit.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <groupId>tools.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.18.2</version>
+            <version>3.0.0-rc2</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.22</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.2</version>
+            <version>3.2.1</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -69,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <release>17</release>
                 </configuration>
@@ -77,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.6</version>
             </plugin>
         </plugins>
     </build>
@@ -91,7 +99,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.3.1</version>
+                        <version>3.4.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -106,7 +114,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.11.1</version>
+                        <version>3.12.0</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -124,7 +132,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.7</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -148,7 +156,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.6.0</version>
+                        <version>0.11.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>

--- a/src/main/java/io/compprov/core/ComputationEnvironment.java
+++ b/src/main/java/io/compprov/core/ComputationEnvironment.java
@@ -1,20 +1,23 @@
 package io.compprov.core;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.compprov.core.meta.Descriptor;
 import io.compprov.core.variable.ValueWithDescriptor;
 import io.compprov.core.variable.VariableKind;
 import io.compprov.core.variable.VariableTrack;
 import io.compprov.core.variable.VariableWrapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.module.SimpleModule;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Clock;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -24,7 +27,7 @@ public class ComputationEnvironment {
 
     protected final Clock clock;
     protected final ZoneId zoneId;
-    protected final ObjectMapper mapper;
+    protected volatile ObjectMapper mapper;
     protected final boolean requireInputDescriptor;
     protected final boolean requireResultDescriptor;
 
@@ -52,20 +55,20 @@ public class ComputationEnvironment {
         wrappers.put(type, wrapper);
     }
 
-    public <T> void registerWrapper(Class<T> type, VariableWrapper<T> wrapper, JsonDeserializer<T> deserializer) {
+    public synchronized <T> void registerWrapper(Class<T> type, VariableWrapper<T> wrapper, ValueDeserializer<T> deserializer) {
         Objects.requireNonNull(type, "type");
         Objects.requireNonNull(wrapper, "wrapper");
         Objects.requireNonNull(deserializer, "deserializer");
         wrappers.put(type, wrapper);
         SimpleModule module = new SimpleModule();
         module.addDeserializer(type, deserializer);
-        mapper.registerModule(module);
+        mapper = mapper.rebuild().addModule(module).build();
     }
 
     public String toJson(Snapshot snapshot) {
         try {
             return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(snapshot);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("JSON serialization failed", e);
         }
     }
@@ -73,7 +76,7 @@ public class ComputationEnvironment {
     public void toJson(Snapshot snapshot, OutputStream os) {
         try {
             mapper.writerWithDefaultPrettyPrinter().writeValue(os, snapshot);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("JSON serialization failed", e);
         }
     }
@@ -81,7 +84,7 @@ public class ComputationEnvironment {
     public Snapshot fromJson(String json) {
         try {
             return mapper.readValue(json, Snapshot.class);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Unable to deserialize JSON", e);
         }
     }
@@ -89,7 +92,7 @@ public class ComputationEnvironment {
     public Snapshot fromJson(byte[] json) {
         try {
             return mapper.readValue(json, Snapshot.class);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Unable to deserialize JSON", e);
         }
     }
@@ -175,7 +178,7 @@ public class ComputationEnvironment {
     private String writeValueSingleString(Object o) {
         try {
             return mapper.writeValueAsString(o);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("JSON serialization failed", e);
         }
     }

--- a/src/main/java/io/compprov/core/DefaultComputationEnvironment.java
+++ b/src/main/java/io/compprov/core/DefaultComputationEnvironment.java
@@ -1,8 +1,6 @@
 package io.compprov.core;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.compprov.core.meta.Descriptor;
 import io.compprov.core.meta.Meta;
 import io.compprov.core.serde.DescriptorDeserializer;
@@ -21,6 +19,8 @@ import io.compprov.core.wrappers.MathContextWrapper;
 import io.compprov.core.wrappers.primitive.IntegerWrapper;
 import io.compprov.core.wrappers.primitive.LongWrapper;
 import io.compprov.core.wrappers.subgraph.SubgraphWrapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.module.SimpleModule;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -90,9 +90,10 @@ public class DefaultComputationEnvironment extends ComputationEnvironment {
         module.addDeserializer(Snapshot.Variable.class, new VariableDeserializer(wrappers));
         module.addDeserializer(Snapshot.Operation.class, new OperationDeserializer());
         module.addDeserializer(Subgraph.class, new SubgraphDeserializer(this));
-        mapper.configOverride(BigDecimal.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING));
-        mapper.configOverride(BigInteger.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING));
-        mapper.registerModule(module);
+        var builder = mapper.rebuild();
+        builder.withConfigOverride(BigDecimal.class, o -> o.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)));
+        builder.withConfigOverride(BigInteger.class, o -> o.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)));
+        mapper = builder.addModule(module).build();
     }
 
     @Override

--- a/src/main/java/io/compprov/core/Subgraph.java
+++ b/src/main/java/io/compprov/core/Subgraph.java
@@ -159,4 +159,9 @@ public class Subgraph {
             this.value = variable.getValue();
         }
     }
+
+    @Override
+    public String toString() {
+        return "Subgraph of " + resultId + argumentIds;
+    }
 }

--- a/src/main/java/io/compprov/core/serde/DescriptorDeserializer.java
+++ b/src/main/java/io/compprov/core/serde/DescriptorDeserializer.java
@@ -1,16 +1,15 @@
 package io.compprov.core.serde;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.compprov.core.meta.Descriptor;
 import io.compprov.core.meta.Meta;
 import io.compprov.core.meta.Pair;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -22,30 +21,22 @@ public class DescriptorDeserializer extends StdDeserializer<Descriptor> {
     }
 
     @Override
-    public Descriptor deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public Descriptor deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        JsonNode node = ctxt.readTree(p);
+        JavaType listOfPairType = ctxt.getTypeFactory().constructCollectionType(ArrayList.class, Pair.class);
+        JavaType mapOfStringObjectType = ctxt.getTypeFactory().constructMapType(LinkedHashMap.class, String.class, Object.class);
 
-        ObjectMapper mapper = (ObjectMapper) p.getCodec();
-        JsonNode node = p.getCodec().readTree(p);
-
-        String name = node.get("name").asText();
+        String name = node.get("name").asString();
         JsonNode metaNode = node.get("meta");
         LinkedHashMap<String, Object> metaMap;
         if (metaNode.isArray()) {
             //to preserve order in JSON
-            List<Pair> metaList = mapper.convertValue(
-                    metaNode,
-                    new TypeReference<ArrayList<Pair>>() {
-                    }
-            );
+            List<Pair> metaList = ctxt.readTreeAsValue(metaNode, listOfPairType);
             metaMap = new LinkedHashMap<>();
             metaList.forEach(pair -> metaMap.put(pair.key(), pair.value()));
         } else {
             //backward compatibility
-            metaMap = mapper.convertValue(
-                    metaNode,
-                    new TypeReference<LinkedHashMap<String, Object>>() {
-                    }
-            );
+            metaMap = ctxt.readTreeAsValue(metaNode, mapOfStringObjectType);
         }
         return new Descriptor(name, new Meta(metaMap));
     }

--- a/src/main/java/io/compprov/core/serde/MathContextDeserializer.java
+++ b/src/main/java/io/compprov/core/serde/MathContextDeserializer.java
@@ -1,11 +1,11 @@
 package io.compprov.core.serde;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.math.MathContext;
 import java.math.RoundingMode;
 
@@ -16,10 +16,10 @@ public class MathContextDeserializer extends StdDeserializer<MathContext> {
     }
 
     @Override
-    public MathContext deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        JsonNode node = p.getCodec().readTree(p);
+    public MathContext deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        JsonNode node = ctxt.readTree(p);
         int precision = node.get("precision").asInt();
-        RoundingMode roundingMode = RoundingMode.valueOf(node.get("roundingMode").asText());
+        RoundingMode roundingMode = RoundingMode.valueOf(node.get("roundingMode").asString());
         return new MathContext(precision, roundingMode);
     }
 }

--- a/src/main/java/io/compprov/core/serde/MetaSerializer.java
+++ b/src/main/java/io/compprov/core/serde/MetaSerializer.java
@@ -1,12 +1,11 @@
 package io.compprov.core.serde;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.compprov.core.meta.Meta;
 import io.compprov.core.meta.Pair;
-
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class MetaSerializer extends StdSerializer<Meta> {
 
@@ -19,8 +18,8 @@ public class MetaSerializer extends StdSerializer<Meta> {
     }
 
     @Override
-    public void serialize(Meta value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        gen.writeObject(value.getParameters().entrySet()
+    public void serialize(Meta value, JsonGenerator gen, SerializationContext ctxt) throws JacksonException {
+        gen.writePOJO(value.getParameters().entrySet()
                 .stream()
                 .map(entry -> new Pair(entry.getKey(), entry.getValue()))
                 .toList());

--- a/src/main/java/io/compprov/core/serde/OperationDeserializer.java
+++ b/src/main/java/io/compprov/core/serde/OperationDeserializer.java
@@ -1,17 +1,16 @@
 package io.compprov.core.serde;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.compprov.core.Snapshot;
 import io.compprov.core.meta.Descriptor;
 import io.compprov.core.meta.Pair;
 import io.compprov.core.operation.OperationTrack;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -24,41 +23,35 @@ public class OperationDeserializer extends StdDeserializer<Snapshot.Operation> {
     }
 
     @Override
-    public Snapshot.Operation deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        ObjectMapper mapper = (ObjectMapper) p.getCodec();
-        JsonNode node = mapper.readTree(p);
+    public Snapshot.Operation deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        JsonNode node = ctxt.readTree(p);
+
+        JavaType listOfPairType = ctxt.getTypeFactory().constructCollectionType(ArrayList.class, Pair.class);
+        JavaType mapOfArgumentsType = ctxt.getTypeFactory().constructMapType(LinkedHashMap.class, String.class, String.class);
 
         final var trackNode = node.get("track");
         int numericId = trackNode.path("numericId").asInt();
-        ZonedDateTime startedAt = ZonedDateTime.parse(trackNode.path("startedAt").asText());
-        ZonedDateTime finishedAt = ZonedDateTime.parse(trackNode.path("finishedAt").asText());
-        Descriptor descriptor = mapper.convertValue(trackNode.path("descriptor"), Descriptor.class);
-        String wrapperClass = trackNode.path("wrapperClass").asText();
+        ZonedDateTime startedAt = ZonedDateTime.parse(trackNode.path("startedAt").asString());
+        ZonedDateTime finishedAt = ZonedDateTime.parse(trackNode.path("finishedAt").asString());
+        Descriptor descriptor = ctxt.readTreeAsValue(trackNode.path("descriptor"), Descriptor.class);
+        String wrapperClass = trackNode.path("wrapperClass").asString();
         final var operationTrack = new OperationTrack(numericId, startedAt, finishedAt, descriptor, wrapperClass);
 
         final var argumentsNode = node.get("arguments");
         List<Pair> argumentsList;
         if (argumentsNode.isArray()) {
             //to preserve order in JSON
-            argumentsList = mapper.convertValue(
-                    argumentsNode,
-                    new TypeReference<ArrayList<Pair>>() {
-                    }
-            );
+            argumentsList = ctxt.readTreeAsValue(argumentsNode, listOfPairType);
         } else {
             //backward compatibility
-            LinkedHashMap<String, String> argumentsMap = mapper.convertValue(
-                    argumentsNode,
-                    new TypeReference<LinkedHashMap<String, String>>() {
-                    }
-            );
+            LinkedHashMap<String, String> argumentsMap = ctxt.readTreeAsValue(argumentsNode, mapOfArgumentsType);
             argumentsList = argumentsMap.entrySet()
                     .stream()
                     .map(entry -> new Pair(entry.getKey(), entry.getValue()))
                     .toList();
         }
 
-        final var resultId = node.get("resultId").asText();
+        final var resultId = node.get("resultId").asString();
         return new Snapshot.Operation(operationTrack, argumentsList, resultId);
     }
 }

--- a/src/main/java/io/compprov/core/serde/SubgraphDeserializer.java
+++ b/src/main/java/io/compprov/core/serde/SubgraphDeserializer.java
@@ -1,18 +1,18 @@
 package io.compprov.core.serde;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.compprov.core.ComputationEnvironment;
 import io.compprov.core.Snapshot;
 import io.compprov.core.Subgraph;
 import io.compprov.core.meta.Descriptor;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 public class SubgraphDeserializer extends StdDeserializer<Subgraph> {
 
@@ -24,18 +24,17 @@ public class SubgraphDeserializer extends StdDeserializer<Subgraph> {
     }
 
     @Override
-    public Subgraph deserialize(JsonParser p, DeserializationContext deserializationContext) throws IOException {
+    public Subgraph deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        JsonNode node = ctxt.readTree(p);
 
-        ObjectMapper mapper = (ObjectMapper) p.getCodec();
-        JsonNode node = mapper.readTree(p);
+        JavaType listOfStringType = ctxt.getTypeFactory().constructCollectionType(ArrayList.class, String.class);
+        JavaType listOfVariableType = ctxt.getTypeFactory().constructCollectionType(ArrayList.class, Snapshot.Variable.class);
+        JavaType listOfOperationType = ctxt.getTypeFactory().constructCollectionType(ArrayList.class, Snapshot.Operation.class);
 
-        final var arguments = mapper.convertValue(node.path("argumentIds"), new TypeReference<ArrayList<String>>() {
-        });
-        final var resultId = node.path("resultId").asText();
-        final var variables = mapper.convertValue(node.path("variables"), new TypeReference<ArrayList<Snapshot.Variable>>() {
-        });
-        final var operations = mapper.convertValue(node.path("operations"), new TypeReference<ArrayList<Snapshot.Operation>>() {
-        });
+        List<String> arguments = ctxt.readTreeAsValue(node.path("argumentIds"), listOfStringType);
+        final var resultId = node.path("resultId").asString();
+        List<Snapshot.Variable> variables = ctxt.readTreeAsValue(node.path("variables"), listOfVariableType);
+        List<Snapshot.Operation> operations = ctxt.readTreeAsValue(node.path("operations"), listOfOperationType);
 
         final var ctx = environment.compute(new Snapshot(Descriptor.descriptor(""), variables, operations));
         return new Subgraph(ctx, arguments, resultId);

--- a/src/main/java/io/compprov/core/serde/SubgraphSerializer.java
+++ b/src/main/java/io/compprov/core/serde/SubgraphSerializer.java
@@ -1,13 +1,12 @@
 package io.compprov.core.serde;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.compprov.core.Subgraph;
 import io.compprov.core.operation.WrappedOperation;
 import io.compprov.core.variable.WrappedVariable;
-
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
 public class SubgraphSerializer extends StdSerializer<Subgraph> {
 
@@ -20,12 +19,12 @@ public class SubgraphSerializer extends StdSerializer<Subgraph> {
     }
 
     @Override
-    public void serialize(Subgraph value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    public void serialize(Subgraph value, JsonGenerator gen, SerializationContext ctxt) throws JacksonException {
         gen.writeStartObject();
-        gen.writeObjectField("argumentIds", value.argumentIds());
-        gen.writeObjectField("resultId", value.resultId());
-        gen.writeObjectField("operations", value.operations().stream().map(WrappedOperation::snapshot).toList());
-        gen.writeObjectField("variables", value.variables().stream().map(WrappedVariable::snapshot).toList());
+        gen.writePOJOProperty("argumentIds", value.argumentIds());
+        gen.writePOJOProperty("resultId", value.resultId());
+        gen.writePOJOProperty("operations", value.operations().stream().map(WrappedOperation::snapshot).toList());
+        gen.writePOJOProperty("variables", value.variables().stream().map(WrappedVariable::snapshot).toList());
         gen.writeEndObject();
     }
 }

--- a/src/main/java/io/compprov/core/serde/VariableDeserializer.java
+++ b/src/main/java/io/compprov/core/serde/VariableDeserializer.java
@@ -1,15 +1,14 @@
 package io.compprov.core.serde;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.compprov.core.Snapshot;
 import io.compprov.core.variable.VariableTrack;
 import io.compprov.core.variable.VariableWrapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -25,13 +24,12 @@ public class VariableDeserializer extends StdDeserializer<Snapshot.Variable> {
     }
 
     @Override
-    public Snapshot.Variable deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        ObjectMapper mapper = (ObjectMapper) p.getCodec();
-        JsonNode node = mapper.readTree(p);
+    public Snapshot.Variable deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        JsonNode node = ctxt.readTree(p);
 
-        VariableTrack track = mapper.convertValue(node.path("track"), VariableTrack.class);
+        VariableTrack track = ctxt.readTreeAsValue(node.path("track"), VariableTrack.class);
         Class<?> valueClass = checkValueClassWrapper(track.getValueClass());
-        Object value = mapper.convertValue(node.path("value"), valueClass);
+        Object value = ctxt.readTreeAsValue(node.path("value"), valueClass);
 
         return new Snapshot.Variable(track, value);
     }

--- a/src/main/java/io/compprov/core/serde/VariableTrackDeserializer.java
+++ b/src/main/java/io/compprov/core/serde/VariableTrackDeserializer.java
@@ -1,15 +1,14 @@
 package io.compprov.core.serde;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.compprov.core.meta.Descriptor;
 import io.compprov.core.variable.VariableKind;
 import io.compprov.core.variable.VariableTrack;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.time.ZonedDateTime;
 
 public class VariableTrackDeserializer extends StdDeserializer<VariableTrack> {
@@ -19,15 +18,14 @@ public class VariableTrackDeserializer extends StdDeserializer<VariableTrack> {
     }
 
     @Override
-    public VariableTrack deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        ObjectMapper mapper = (ObjectMapper) p.getCodec();
-        JsonNode node = mapper.readTree(p);
+    public VariableTrack deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        JsonNode node = ctxt.readTree(p);
 
         int numericId = node.path("numericId").asInt();
-        ZonedDateTime createdAt = ZonedDateTime.parse(node.path("createdAt").asText());
-        VariableKind kind = mapper.convertValue(node.path("kind"), VariableKind.class);
-        Descriptor descriptor = mapper.convertValue(node.path("descriptor"), Descriptor.class);
-        String valueClass = node.path("valueClass").asText();
+        ZonedDateTime createdAt = ZonedDateTime.parse(node.path("createdAt").asString());
+        VariableKind kind = ctxt.readTreeAsValue(node.path("kind"), VariableKind.class);
+        Descriptor descriptor = ctxt.readTreeAsValue(node.path("descriptor"), Descriptor.class);
+        String valueClass = node.path("valueClass").asString();
         return new VariableTrack(numericId, createdAt, kind, descriptor, valueClass);
     }
 }

--- a/src/main/java/io/compprov/core/serde/ZonedDateTimeSerializer.java
+++ b/src/main/java/io/compprov/core/serde/ZonedDateTimeSerializer.java
@@ -1,10 +1,10 @@
 package io.compprov.core.serde;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 
-import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -21,7 +21,7 @@ public class ZonedDateTimeSerializer extends StdSerializer<ZonedDateTime> {
     }
 
     @Override
-    public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(ZonedDateTime value, JsonGenerator gen, SerializationContext ctxt) throws JacksonException {
         if (value == null) {
             gen.writeNull();
             return;

--- a/src/main/java/io/compprov/core/wrappers/WrappedBigDecimal.java
+++ b/src/main/java/io/compprov/core/wrappers/WrappedBigDecimal.java
@@ -46,6 +46,7 @@ public final class WrappedBigDecimal extends AbstractWrappedVariable<BigDecimal>
     private static final Descriptor OP_MIN_BULK = Descriptor.descriptor("minBulk", formula("min(a,b0,...,bn)"));
     private static final Descriptor OP_LN_DOUBLE = Descriptor.descriptor("Ln_double", formula("Ln(a)"));
     private static final Descriptor OP_EXP_DOUBLE = Descriptor.descriptor("Exp_double", formula("Exp(a)"));
+    private static final Descriptor OP_COMPARE = Descriptor.descriptor("compare", formula("a.compare(b)"));
 
     private static final Map<Descriptor, Function<List<Object>, Object>> functionsMap;
 
@@ -231,6 +232,12 @@ public final class WrappedBigDecimal extends AbstractWrappedVariable<BigDecimal>
             return BigDecimal.valueOf(dirty);
         });
 
+        functions.put(OP_COMPARE, (arguments) -> {
+            BigDecimal a = (BigDecimal) arguments.get(0);
+            BigDecimal b = (BigDecimal) arguments.get(1);
+            return BigDecimal.valueOf(a.compareTo(b));
+        });
+
         functionsMap = Collections.unmodifiableMap(functions);
     }
 
@@ -385,8 +392,7 @@ public final class WrappedBigDecimal extends AbstractWrappedVariable<BigDecimal>
     }
 
     /**
-     *
-     * @param mc, newScale is taken from mc.precision and rounding mode is mc.roundingMode.
+     * @param mc,              newScale is taken from mc.precision and rounding mode is mc.roundingMode.
      * @param resultDescriptor
      * @return
      */
@@ -513,6 +519,15 @@ public final class WrappedBigDecimal extends AbstractWrappedVariable<BigDecimal>
         return (WrappedBigDecimal) execute(
                 OP_EXP_DOUBLE,
                 "a", this,
+                resultDescriptor);
+    }
+
+    public WrappedBigDecimal compare(WrappedBigDecimal b, Descriptor resultDescriptor) {
+        Objects.requireNonNull(b, "b");
+        return (WrappedBigDecimal) execute(
+                OP_COMPARE,
+                "a", this,
+                "b", b,
                 resultDescriptor);
     }
 }

--- a/src/main/java/io/compprov/core/wrappers/WrappedBigInteger.java
+++ b/src/main/java/io/compprov/core/wrappers/WrappedBigInteger.java
@@ -8,7 +8,12 @@ import io.compprov.core.variable.WrappedVariable;
 import io.compprov.core.wrappers.primitive.WrappedInteger;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 import static io.compprov.core.meta.Meta.formula;
@@ -48,6 +53,7 @@ public final class WrappedBigInteger extends AbstractWrappedVariable<BigInteger>
     private static final Descriptor OP_MULTIPLY_BULK = Descriptor.descriptor("multiplyBulk", formula("a*b0*...*bn"));
     private static final Descriptor OP_MAX_BULK = Descriptor.descriptor("maxBulk", formula("max(a,b0,...,bn)"));
     private static final Descriptor OP_MIN_BULK = Descriptor.descriptor("minBulk", formula("min(a,b0,...,bn)"));
+    private static final Descriptor OP_COMPARE = Descriptor.descriptor("compare", formula("a.compare(b)"));
 
     private static final Map<Descriptor, Function<List<Object>, Object>> functionsMap;
 
@@ -239,6 +245,12 @@ public final class WrappedBigInteger extends AbstractWrappedVariable<BigInteger>
                 result = result.min((BigInteger) arguments.get(i));
             }
             return result;
+        });
+
+        functions.put(OP_COMPARE, (arguments) -> {
+            BigInteger a = (BigInteger) arguments.get(0);
+            BigInteger b = (BigInteger) arguments.get(1);
+            return BigInteger.valueOf(a.compareTo(b));
         });
 
         functionsMap = Collections.unmodifiableMap(functions);
@@ -529,5 +541,14 @@ public final class WrappedBigInteger extends AbstractWrappedVariable<BigInteger>
             arguments.put("b" + i, values.get(i));
         }
         return (WrappedBigInteger) execute(OP_MIN_BULK, arguments, resultDescriptor);
+    }
+
+    public WrappedBigInteger compare(WrappedBigInteger b, Descriptor resultDescriptor) {
+        Objects.requireNonNull(b, "b");
+        return (WrappedBigInteger) execute(
+                OP_COMPARE,
+                "a", this,
+                "b", b,
+                resultDescriptor);
     }
 }

--- a/src/test/java/io/compprov/examples/hydrology/HydrologyDataProvider.java
+++ b/src/test/java/io/compprov/examples/hydrology/HydrologyDataProvider.java
@@ -1,8 +1,9 @@
 package io.compprov.examples.hydrology;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.compprov.examples.nav.NetAssetValueCalculator;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -16,7 +17,7 @@ import java.util.Objects;
  */
 public class HydrologyDataProvider {
 
-    private Map<String, List<BigDecimal>> dataMap;
+    private final Map<String, List<BigDecimal>> dataMap;
 
     public HydrologyDataProvider(ObjectMapper mapper) {
         try {
@@ -24,7 +25,7 @@ public class HydrologyDataProvider {
                     NetAssetValueCalculator.class.getResourceAsStream("/inputs/hydrology_aggregation.json").readAllBytes(),
                     new TypeReference<Map<String, List<BigDecimal>>>() {
                     });
-        } catch (IOException e) {
+        } catch (IOException | JacksonException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/test/java/io/compprov/examples/nav/wrapped/AmountDeserializer.java
+++ b/src/test/java/io/compprov/examples/nav/wrapped/AmountDeserializer.java
@@ -1,15 +1,14 @@
 package io.compprov.examples.nav.wrapped;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.compprov.examples.nav.model.Amount;
 import io.compprov.examples.nav.model.Currency;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
 
-import java.io.IOException;
 import java.math.BigDecimal;
-import java.math.MathContext;
 
 /**
  * Amount might be represented as a record, but here we want to show how to register deserializers for custom types
@@ -21,10 +20,10 @@ public class AmountDeserializer extends StdDeserializer<Amount> {
     }
 
     @Override
-    public Amount deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        JsonNode node = p.getCodec().readTree(p);
-        Currency currency = Currency.valueOf(node.get("currency").asText());
-        BigDecimal amount = new BigDecimal(node.get("amount").asText());
+    public Amount deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        JsonNode node = ctxt.readTree(p);
+        Currency currency = Currency.valueOf(node.get("currency").asString());
+        BigDecimal amount = new BigDecimal(node.get("amount").asString());
         return new Amount(currency, amount);
     }
 }

--- a/src/test/java/io/compprov/examples/pi/MonteCarloArcsineIntegrationStress.java
+++ b/src/test/java/io/compprov/examples/pi/MonteCarloArcsineIntegrationStress.java
@@ -1,0 +1,161 @@
+package io.compprov.examples.pi;
+
+import io.compprov.core.ComputationEnvironment;
+import io.compprov.core.DataContext;
+import io.compprov.core.DefaultComputationContext;
+import io.compprov.core.DefaultComputationEnvironment;
+import io.compprov.core.Subgraph;
+import io.compprov.core.wrappers.WrappedBigDecimal;
+import io.compprov.core.wrappers.WrappedMathContext;
+import io.compprov.core.wrappers.primitive.WrappedInteger;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Random;
+
+import static io.compprov.core.meta.Descriptor.descriptor;
+
+/**
+ * Same graph-fold stress-test shape as {@link io.compprov.examples.pi.PiCalculationStress}, estimating the definite integral of
+ * {@code f(x) = 1/sqrt(1-x^2)} over {@code [0, 1]}, whose antiderivative is {@code arcsin(x)}, so the exact
+ * value is {@code arcsin(1) - arcsin(0) = pi/2}.
+ * <p>
+ * {@code f} is unbounded as {@code x} approaches 1, so rejection sampling against a bounding box doesn't apply here
+ * (there is no finite {@code Y_TO}). This uses the average-value method instead:
+ * {@code integral ~= (b - a) * average(f(x_i))} for x_i drawn uniformly
+ * from {@code [0, 1)}. Because {@code Var(f)} is itself infinite (the singularity at x=1 is integrable but
+ * {@code f^2} is not), convergence is slower and noisier than the polynomial examples.
+ */
+public class MonteCarloArcsineIntegrationStress {
+
+    private static final ComputationEnvironment ENVIRONMENT = DefaultComputationEnvironment.create();
+    private static final Random random = new Random();
+
+    private static final BigDecimal LOWER_BOUND = BigDecimal.ZERO;
+    private static final BigDecimal UPPER_BOUND = BigDecimal.ONE;
+    private static final BigDecimal RANGE = UPPER_BOUND.subtract(LOWER_BOUND);
+
+    private static final BigDecimal ACTUAL_PI = new BigDecimal("3.14159265358979323846");
+
+    //@Test skipped, too huge for automatic testing
+    public void test() throws Exception {
+
+        final var step = 1000;
+        final var totalPointsMax = 250000;
+
+        //warm up (heap memory allocation etc)
+        BigDecimal warmUpAmount = BigDecimal.valueOf(totalPointsMax);
+        calculatePure(warmUpAmount);
+        calculateCompProv(warmUpAmount);
+
+        System.out.println("N\tJPC time\tCompProv time\tCPG memory");
+        for (int tp = 10000; tp <= totalPointsMax; tp += step) {
+            BigDecimal tpBD = BigDecimal.valueOf(tp);
+            final var pureTime = calculatePure(tpBD);
+
+            System.gc();
+            System.runFinalization();
+            Thread.sleep(1000);
+            final var compProvTime = calculateCompProv(tpBD);
+
+            final var cpgSize = Files.size(new File("integral.json").toPath());
+            System.out.println("%s\t%s\t%s\t%s".formatted(tp, pureTime, compProvTime, cpgSize));
+        }
+    }
+
+    public long calculatePure(BigDecimal totalPointsBD) {
+
+        long nano = System.nanoTime();
+
+        final var mc = MathContext.DECIMAL128;
+        final var one = BigDecimal.ONE;
+
+        var fxSum = BigDecimal.ZERO;
+        for (long i = 0; i < totalPointsBD.longValue(); i++) {
+
+            // random.nextDouble() is always < 1.0, so 1-x^2 never hits zero
+            final var x = BigDecimal.valueOf(random.nextDouble());
+            final var oneMinusXSquared = one.subtract(x.pow(2, mc), mc);
+            final var fx = one.divide(oneMinusXSquared.sqrt(mc), mc);
+
+            fxSum = fxSum.add(fx, mc);
+        }
+
+        final var average = fxSum.divide(totalPointsBD, mc);
+        final var estimatedIntegral = average.multiply(RANGE, mc);
+        final var estimatedPi = estimatedIntegral.multiply(BigDecimal.valueOf(2));
+        final var error = ACTUAL_PI.subtract(estimatedPi, mc).abs(mc);
+
+        return System.nanoTime() - nano;
+    }
+
+    public long calculateCompProv(BigDecimal totalPointsBD) throws IOException {
+
+        long nano = System.nanoTime();
+
+        //subgraph: a single sample, x -> 1/sqrt(1-x^2)
+        final var subctx = new DefaultComputationContext(ENVIRONMENT,
+                new DataContext(descriptor("Monte Carlo sample of 1/sqrt(1-x^2)")));
+        {
+            final var x = subctx.wrapBigDecimal(BigDecimal.ZERO, descriptor("x"));
+            final var mc = subctx.wrapMathContext(MathContext.DECIMAL128, descriptor("computation precision"));
+            final var one = subctx.wrapBigDecimal(BigDecimal.ONE, descriptor("Constant 1"));
+            final var twoInt = subctx.wrapInteger(2, descriptor("Constant 2 (int)"));
+            sampleValue(x, one, twoInt, mc, "x");
+        }
+
+        final var ctx = new DefaultComputationContext(ENVIRONMENT,
+                new DataContext(descriptor("Monte Carlo integration of 1/sqrt(1-x^2) in range [0;1] with %s points".formatted(totalPointsBD))));
+        final var mc = ctx.wrapMathContext(MathContext.DECIMAL128, descriptor("computation precision"));
+        final var totalPoints = ctx.wrapBigDecimal(totalPointsBD, descriptor("Total points"));
+        final var range = ctx.wrapBigDecimal(RANGE, descriptor("integration range"));
+        final var two = ctx.wrapBigDecimal(BigDecimal.valueOf(2), descriptor("Constant 2"));
+        final var pi = ctx.wrapBigDecimal(ACTUAL_PI, descriptor("Constant Pi"));
+
+        var fxSum = ctx.wrapBigDecimal(BigDecimal.ZERO, descriptor("f(x) sum"));
+        final var sampleSubgraph = ctx.wrapSubgraph(
+                new Subgraph(
+                        subctx,
+                        List.of(subctx.findSingleVariable("x").getVariableTrack().getId()),
+                        subctx.findSingleVariable("x_fx").getVariableTrack().getId()),
+                subctx.descriptor());
+        for (long i = 0; i < totalPoints.getValue().longValue(); i++) {
+
+            final var x = ctx.wrapBigDecimal(BigDecimal.valueOf(random.nextDouble()), descriptor("x_" + i));
+            final var fx = (WrappedBigDecimal) sampleSubgraph.execute(List.of(x), descriptor("fx_" + i));
+
+            fxSum = fxSum.add(fx, mc, descriptor("counter " + i));
+        }
+
+        final var average = fxSum.divide(totalPoints, mc, descriptor("average f(x)"));
+        final var estimatedIntegral = average.multiply(range, mc, descriptor("estimated integral"));
+        // integral * 2
+        final var estimatedPi = estimatedIntegral.multiply(two, mc, descriptor("estimated Pi"));
+        final var error = estimatedPi.subtract(pi, mc, descriptor("error")).abs(mc, descriptor("|error|"));
+
+        nano = System.nanoTime() - nano;
+
+        final var fos = new FileOutputStream("integral.json");
+        final var snapshot = ctx.snapshot();
+        ENVIRONMENT.toJson(snapshot, fos);
+        fos.close();
+        return nano;
+    }
+
+    /**
+     * Evaluates {@code f(x) = 1/sqrt(1-x^2)} at the given sample point.
+     */
+    private static WrappedBigDecimal sampleValue(WrappedBigDecimal x, WrappedBigDecimal one,
+                                                 WrappedInteger twoInt,
+                                                 WrappedMathContext mc, String namePrefix) {
+        final var xSquared = x.pow(twoInt, mc, descriptor(namePrefix + "^2"));
+        final var oneMinusXSquared = one.subtract(xSquared, mc, descriptor("1-" + namePrefix + "^2"));
+        final var sqrtVal = oneMinusXSquared.sqrt(mc, descriptor("sqrt(1-" + namePrefix + "^2)"));
+        return one.divide(sqrtVal, mc, descriptor(namePrefix + "_fx"));
+    }
+}

--- a/src/test/java/io/compprov/examples/pi/MonteCarloArcsineIntegrationStressParallel.java
+++ b/src/test/java/io/compprov/examples/pi/MonteCarloArcsineIntegrationStressParallel.java
@@ -1,0 +1,173 @@
+package io.compprov.examples.pi;
+
+import io.compprov.core.ComputationEnvironment;
+import io.compprov.core.DataContext;
+import io.compprov.core.DefaultComputationContext;
+import io.compprov.core.DefaultComputationEnvironment;
+import io.compprov.core.Subgraph;
+import io.compprov.core.wrappers.WrappedBigDecimal;
+import io.compprov.core.wrappers.WrappedMathContext;
+import io.compprov.core.wrappers.primitive.WrappedInteger;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static io.compprov.core.meta.Descriptor.descriptor;
+
+/**
+ * Same graph-fold stress-test shape as {@link PiCalculationStress}, estimating the definite integral of
+ * {@code f(x) = 1/sqrt(1-x^2)} over {@code [0, 1]}, whose antiderivative is {@code arcsin(x)}, so the exact
+ * value is {@code arcsin(1) - arcsin(0) = pi/2}.
+ * <p>
+ * {@code f} is unbounded as {@code x} approaches 1, so rejection sampling against a bounding box doesn't apply here
+ * (there is no finite {@code Y_TO}). This uses the average-value method instead:
+ * {@code integral ~= (b - a) * average(f(x_i))} for x_i drawn uniformly
+ * from {@code [0, 1)}. Because {@code Var(f)} is itself infinite (the singularity at x=1 is integrable but
+ * {@code f^2} is not), convergence is slower and noisier than the polynomial examples.
+ */
+public class MonteCarloArcsineIntegrationStressParallel {
+
+    private static final ComputationEnvironment ENVIRONMENT = DefaultComputationEnvironment.create();
+    private static final ThreadLocal<Random> random = ThreadLocal.withInitial(Random::new);
+    private static final ExecutorService executorService = Executors.newFixedThreadPool(4);
+
+    private static final BigDecimal LOWER_BOUND = BigDecimal.ZERO;
+    private static final BigDecimal UPPER_BOUND = BigDecimal.ONE;
+    private static final BigDecimal RANGE = UPPER_BOUND.subtract(LOWER_BOUND);
+
+    private static final BigDecimal ACTUAL_PI = new BigDecimal("3.14159265358979323846");
+
+    //@Test skipped, too huge for automatic testing
+    public void test() throws Exception {
+
+        final var step = 1000;
+        final var totalPointsMax = 250000;
+
+        //warm up (heap memory allocation etc)
+        BigDecimal warmUpAmount = BigDecimal.valueOf(totalPointsMax);
+        calculatePure(warmUpAmount);
+        calculateCompProv(warmUpAmount);
+
+        System.out.println("N\tJPC time\tCompProv time");
+        for (int tp = 10000; tp <= totalPointsMax; tp += step) {
+            BigDecimal tpBD = BigDecimal.valueOf(tp);
+            final var pureTime = calculatePure(tpBD);
+
+            System.gc();
+            System.runFinalization();
+            Thread.sleep(1000);
+            final var compProvTime = calculateCompProv(tpBD);
+
+            System.out.println("%s\t%s\t%s".formatted(tp, pureTime, compProvTime));
+        }
+    }
+
+    public long calculatePure(BigDecimal totalPointsBD) {
+
+        long nano = System.nanoTime();
+
+        final var mc = MathContext.DECIMAL128;
+        final var one = BigDecimal.ONE;
+
+        List<Future<BigDecimal>> results = new ArrayList<>();
+        for (long i = 0; i < totalPointsBD.longValue(); i++) {
+            results.add(executorService.submit(() -> {
+                // random.nextDouble() is always < 1.0, so 1-x^2 never hits zero
+                final var x = BigDecimal.valueOf(random.get().nextDouble());
+                final var oneMinusXSquared = one.subtract(x.pow(2, mc), mc);
+                return one.divide(oneMinusXSquared.sqrt(mc), mc);
+            }));
+        }
+
+        var fxSum = results.stream().map(f -> {
+            try {
+                return f.get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }).reduce(BigDecimal::add).get();
+
+        final var average = fxSum.divide(totalPointsBD, mc);
+        final var estimatedIntegral = average.multiply(RANGE, mc);
+        final var estimatedPi = estimatedIntegral.multiply(BigDecimal.valueOf(2));
+        final var error = ACTUAL_PI.subtract(estimatedPi, mc).abs(mc);
+
+        return System.nanoTime() - nano;
+    }
+
+    public long calculateCompProv(BigDecimal totalPointsBD) throws IOException {
+
+        long nano = System.nanoTime();
+
+        //subgraph: a single sample, x -> 1/sqrt(1-x^2)
+        final var subctx = new DefaultComputationContext(ENVIRONMENT,
+                new DataContext(descriptor("Monte Carlo sample of 1/sqrt(1-x^2)")));
+        {
+            final var x = subctx.wrapBigDecimal(BigDecimal.ZERO, descriptor("x"));
+            final var mc = subctx.wrapMathContext(MathContext.DECIMAL128, descriptor("computation precision"));
+            final var one = subctx.wrapBigDecimal(BigDecimal.ONE, descriptor("Constant 1"));
+            final var twoInt = subctx.wrapInteger(2, descriptor("Constant 2 (int)"));
+            sampleValue(x, one, twoInt, mc, "x");
+        }
+
+        final var ctx = new DefaultComputationContext(ENVIRONMENT,
+                new DataContext(descriptor("Monte Carlo integration of 1/sqrt(1-x^2) in range [0;1] with %s points".formatted(totalPointsBD))));
+        final var mc = ctx.wrapMathContext(MathContext.DECIMAL128, descriptor("computation precision"));
+        final var totalPoints = ctx.wrapBigDecimal(totalPointsBD, descriptor("Total points"));
+        final var range = ctx.wrapBigDecimal(RANGE, descriptor("integration range"));
+        final var two = ctx.wrapBigDecimal(BigDecimal.valueOf(2), descriptor("Constant 2"));
+        final var pi = ctx.wrapBigDecimal(ACTUAL_PI, descriptor("Constant Pi"));
+
+        var fxSum = ctx.wrapBigDecimal(BigDecimal.ZERO, descriptor("f(x) sum initial"));
+        final var sampleSubgraph = ctx.wrapSubgraph(
+                new Subgraph(
+                        subctx,
+                        List.of(subctx.findSingleVariable("x").getVariableTrack().getId()),
+                        subctx.findSingleVariable("x_fx").getVariableTrack().getId()),
+                subctx.descriptor());
+
+        List<Future<WrappedBigDecimal>> results = new ArrayList<>();
+        for (long i = 0; i < totalPoints.getValue().longValue(); i++) {
+            final var final_i = i;
+            results.add(executorService.submit(() -> {
+                final var x = ctx.wrapBigDecimal(BigDecimal.valueOf(random.get().nextDouble()), descriptor("x_" + final_i));
+                return (WrappedBigDecimal) sampleSubgraph.executeConcurrent(List.of(x), descriptor("fx_" + final_i));
+            }));
+        }
+        fxSum = fxSum.addBulk(results.stream().map(f -> {
+            try {
+                return f.get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }).toList(), mc, descriptor("Sum of samples"));
+        final var average = fxSum.divide(totalPoints, mc, descriptor("average f(x)"));
+        final var estimatedIntegral = average.multiply(range, mc, descriptor("estimated integral"));
+        // integral * 2
+        final var estimatedPi = estimatedIntegral.multiply(two, mc, descriptor("estimated Pi"));
+        final var error = estimatedPi.subtract(pi, mc, descriptor("error")).abs(mc, descriptor("|error|"));
+
+        nano = System.nanoTime() - nano;
+
+        return nano;
+    }
+
+    /**
+     * Evaluates {@code f(x) = 1/sqrt(1-x^2)} at the given sample point.
+     */
+    private static WrappedBigDecimal sampleValue(WrappedBigDecimal x, WrappedBigDecimal one,
+                                                 WrappedInteger twoInt,
+                                                 WrappedMathContext mc, String namePrefix) {
+        final var xSquared = x.pow(twoInt, mc, descriptor(namePrefix + "^2"));
+        final var oneMinusXSquared = one.subtract(xSquared, mc, descriptor("1-" + namePrefix + "^2"));
+        final var sqrtVal = oneMinusXSquared.sqrt(mc, descriptor("sqrt(1-" + namePrefix + "^2)"));
+        return one.divide(sqrtVal, mc, descriptor(namePrefix + "_fx"));
+    }
+}

--- a/src/test/java/io/compprov/examples/pi/PiCalculationStress.java
+++ b/src/test/java/io/compprov/examples/pi/PiCalculationStress.java
@@ -35,9 +35,9 @@ public class PiCalculationStress {
         BigDecimal warmUpAmount = BigDecimal.valueOf(totalPointsMax);
         calculatePure(warmUpAmount);
         calculateCompProv(warmUpAmount);
-        calculateCompProvWithFragmentation(warmUpAmount);
+        calculateCompProvFolded(warmUpAmount);
 
-        System.out.println("N\tJPC time\tCompProv time\tCompProv frag time\tCPG memory\tCPG frag memory");
+        System.out.println("N\tJPC time\tCompProv time\tCompProv folded time\tCPG memory\tCPG folded memory");
         for (int tp = 10000; tp <= totalPointsMax; tp += step) {
             System.gc();
             System.runFinalization();
@@ -50,10 +50,10 @@ public class PiCalculationStress {
             System.runFinalization();
             Thread.sleep(1000);
 
-            final var compProvTimeFragmentation = calculateCompProvWithFragmentation(tpBD);
+            final var compProvTimeFragmentation = calculateCompProvFolded(tpBD);
             final var cpgSize = Files.size(new File("pi.json").toPath());
-            final var cpgFragSize = Files.size(new File("pi_frag.json").toPath());
-            System.out.println("%s\t%s\t%s\t%s\t%s\t%s".formatted(tp, pureTime, compProvTime, compProvTimeFragmentation, cpgSize, cpgFragSize));
+            final var cpgFoldedSize = Files.size(new File("pi_folded.json").toPath());
+            System.out.println("%s\t%s\t%s\t%s\t%s\t%s".formatted(tp, pureTime, compProvTime, compProvTimeFragmentation, cpgSize, cpgFoldedSize));
         }
     }
 
@@ -141,7 +141,7 @@ public class PiCalculationStress {
         return nano;
     }
 
-    public long calculateCompProvWithFragmentation(BigDecimal totalPointsBD) throws IOException {
+    public long calculateCompProvFolded(BigDecimal totalPointsBD) throws IOException {
 
         long nano = System.nanoTime();
 
@@ -200,7 +200,7 @@ public class PiCalculationStress {
 
         nano = System.nanoTime() - nano;
 
-        final var fos = new FileOutputStream("pi_frag.json");
+        final var fos = new FileOutputStream("pi_folded.json");
         final var snapshot = ctx.snapshot();
         final var nodes = snapshot.variables().size() + snapshot.operations().size();
         final var edges = snapshot.operations().size() + snapshot.operations().stream().mapToInt(operation -> operation.arguments().size()).sum();

--- a/src/test/java/io/compprov/examples/pi/PiCalculator.java
+++ b/src/test/java/io/compprov/examples/pi/PiCalculator.java
@@ -95,6 +95,7 @@ public class PiCalculator {
         //recover calculations
         final var recalculated = ENVIRONMENT.compute(snapshot);
         final var result = recalculated.findSingleVariable("estimated Pi").getValue();
+        System.out.println(ENVIRONMENT.toHumanReadableLog(snapshot));
 
         //To reduce GH repository storage, there are just 100 cycles
         assertEquals(new BigDecimal("3.24"), result);


### PR DESCRIPTION
- [x] Migrate JSON serialization from Jackson 2.x to Jackson 3.x (tools.jackson.* for core/databind; jackson-annotations stays on the 2.x groupId/package)
- [x] Add compare() to WrappedBigDecimal and WrappedBigInteger
- [x] Add Monte-Carlo Arcsin integration stress tests, sequential and executeConcurrent-parallel variants, demonstrating subgraph folding on an unbounded integrand
- [x] Rename PiCalculationStress's folded-computation path/output for clarity (calculateCompProvFolded, pi_folded.json)
- [x] Update README with pointers to the new examples and Jackson 3 custom-deserializer guidance
