### PR TITLE
Add SnapshotNavigator and  EnvironmentCustomizer 

### DIFF
--- a/src/main/java/io/compprov/EnvironmentCustomizer.java
+++ b/src/main/java/io/compprov/EnvironmentCustomizer.java
@@ -1,0 +1,7 @@
+package io.compprov;
+
+import io.compprov.core.ComputationEnvironment;
+
+public interface EnvironmentCustomizer {
+    void customize(ComputationEnvironment environment);
+}

--- a/src/main/java/io/compprov/core/ComputationEnvironment.java
+++ b/src/main/java/io/compprov/core/ComputationEnvironment.java
@@ -6,6 +6,7 @@ import io.compprov.core.variable.VariableKind;
 import io.compprov.core.variable.VariableTrack;
 import io.compprov.core.variable.VariableWrapper;
 import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JacksonModule;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ValueDeserializer;
 import tools.jackson.databind.module.SimpleModule;
@@ -63,6 +64,14 @@ public class ComputationEnvironment {
         SimpleModule module = new SimpleModule();
         module.addDeserializer(type, deserializer);
         mapper = mapper.rebuild().addModule(module).build();
+    }
+
+    public synchronized <T> void registerWrapper(Class<T> type, VariableWrapper<T> wrapper, JacksonModule jacksonModule) {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(wrapper, "wrapper");
+        Objects.requireNonNull(jacksonModule, "jacksonModule");
+        wrappers.put(type, wrapper);
+        mapper = mapper.rebuild().addModule(jacksonModule).build();
     }
 
     public String toJson(Snapshot snapshot) {

--- a/src/main/java/io/compprov/tools/SnapshotNavigator.java
+++ b/src/main/java/io/compprov/tools/SnapshotNavigator.java
@@ -1,0 +1,331 @@
+package io.compprov.tools;
+
+import io.compprov.core.Snapshot;
+import io.compprov.core.meta.Descriptor;
+import io.compprov.core.operation.WrappedArgumentId;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Navigates and queries a {@link Snapshot} computational provenance graph (CPG).
+ * <p>
+ * Index maps are built once at construction time; all query methods run in O(result size).
+ */
+public class SnapshotNavigator {
+
+    private final Snapshot snapshot;
+    private final Set<String> leafIds;
+    private final Set<String> rootIds;
+
+    private final Map<String, Snapshot.Variable> variables;
+    private final Map<String, Snapshot.Operation> operations;
+    private final Map<String, Snapshot.Operation> producedBy;
+    private final Map<String, List<Snapshot.Operation>> participatesIn;
+
+    /**
+     * Builds navigation indexes from the given snapshot.
+     */
+    public SnapshotNavigator(Snapshot snapshot) {
+        this.snapshot = snapshot;
+        variables = new HashMap<>();
+        operations = new HashMap<>();
+        producedBy = new HashMap<>();
+        participatesIn = new HashMap<>();
+        leafIds = new HashSet<>();
+        rootIds = new HashSet<>();
+
+        for (var operation : snapshot.operations()) {
+            operations.put(operation.track().getId(), operation);
+            producedBy.put(operation.resultId(), operation);
+            operation.arguments().stream().map(WrappedArgumentId::variableId).map(Object::toString).forEach(inputId -> {
+                participatesIn.computeIfAbsent(inputId, (id) -> new ArrayList<>()).add(operation);
+            });
+        }
+
+        snapshot.variables().forEach(variable -> {
+            String id = variable.track().getId();
+            variables.put(id, variable);
+            if (!producedBy.containsKey(variable.track().getId())) { //to avoid falsification through Kind
+                rootIds.add(id);
+            }
+
+            if (!participatesIn.containsKey(id)) {
+                leafIds.add(id);
+            }
+        });
+    }
+
+    /**
+     * Returns variables that are not consumed by any operation (terminal outputs).
+     */
+    public List<Snapshot.Variable> leaves() {
+        return leafIds.stream().map(this::getVariable).toList();
+    }
+
+    /**
+     * Returns all input variables.
+     */
+    public List<Snapshot.Variable> roots() {
+        return rootIds.stream().map(this::getVariable).toList();
+    }
+
+    /**
+     * Returns input variables that do not participate in any operation.
+     */
+    public List<Snapshot.Variable> unused() {
+        return rootIds
+                .stream()
+                .filter(id -> !participatesIn.containsKey(id))
+                .map(this::getVariable)
+                .toList();
+    }
+
+    /**
+     * Returns variables directly produced by operations that consume the given variable (one hop forward).
+     *
+     * @param variableId source variable ID
+     */
+    public List<Snapshot.Variable> produces(String variableId) {
+        List<Snapshot.Operation> ops = participatesIn.get(variableId);
+        if (ops == null) {
+            return Collections.emptyList();
+        }
+        return ops.stream().map(Snapshot.Operation::resultId).map(this::getVariable).toList();
+    }
+
+    /**
+     * Returns the operation that produced the given variable, or empty if it is a root.
+     *
+     * @param variableId target variable ID
+     */
+    public Optional<Snapshot.Operation> producedBy(String variableId) {
+        return Optional.ofNullable(producedBy.get(variableId));
+    }
+
+    /**
+     * Returns the direct input variables of the operation that produced the given variable (one hop backward).
+     * Returns an empty list if the variable has no producing operation.
+     *
+     * @param variableId target variable ID
+     */
+    public List<Snapshot.Variable> dependsOn(String variableId) {
+        final var operation = producedBy.get(variableId);
+        if (operation == null) {
+            return Collections.emptyList();
+        }
+
+        return operation.arguments()
+                .stream()
+                .map(WrappedArgumentId::variableId)
+                .map(Object::toString)
+                .map(this::getVariable)
+                .distinct()
+                .toList();
+    }
+
+    /**
+     * Returns all variables transitively produced by the given variable (full forward closure).
+     *
+     * @param variableId source variable ID
+     */
+    public List<Snapshot.Variable> producesDeep(String variableId) {
+        return producesDeep(variableId, Collections.emptySet());
+    }
+
+    /**
+     * Returns the forward transitive closure from the given variable, stopping traversal at any variable in
+     * {@code stopVariables}. Stop variables themselves are excluded from the result.
+     *
+     * @param variableId    source variable ID
+     * @param stopVariables variable IDs at which traversal halts
+     */
+    public List<Snapshot.Variable> producesDeep(String variableId, Set<String> stopVariables) {
+        if (stopVariables.contains(variableId)) {
+            return Collections.emptyList();
+        }
+        Map<String, Snapshot.Variable> result = new HashMap<>();
+        final var producedVariables = produces(variableId);
+        for (var producedVariable : producedVariables) {
+            result.put(producedVariable.track().getId(), producedVariable);
+            producesDeep(producedVariable.track().getId(), stopVariables)
+                    .forEach(variable -> result.put(variable.track().getId(), variable));
+        }
+        return result.values().stream().toList();
+    }
+
+    /**
+     * Returns all operations in the full production ancestry of the given variable.
+     *
+     * @param variableId target variable ID
+     */
+    public List<Snapshot.Operation> producedByDeep(String variableId) {
+        return producedByDeep(variableId, Collections.emptySet());
+    }
+
+    /**
+     * Returns ancestral operations of the given variable, stopping at variables in {@code stopVariables}.
+     *
+     * @param variableId    target variable ID
+     * @param stopVariables variable IDs at which traversal halts
+     */
+    public List<Snapshot.Operation> producedByDeep(String variableId, Set<String> stopVariables) {
+        if (stopVariables.contains(variableId)) {
+            return Collections.emptyList();
+        }
+        final var producedByOperation = producedBy(variableId);
+        if (producedByOperation.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<String, Snapshot.Operation> result = new HashMap<>();
+        producedByOperation.ifPresent(operation -> {
+            result.put(operation.track().getId(), operation);
+            operation.arguments()
+                    .stream()
+                    .map(WrappedArgumentId::variableId)
+                    .map(Object::toString)
+                    .map(varId -> producedByDeep(varId, stopVariables))
+                    .flatMap(Collection::stream)
+                    .forEach(op -> result.put(op.track().getId(), op));
+        });
+        return result.values().stream().toList();
+    }
+
+    /**
+     * Returns all variables the given variable transitively depends on (full backward closure).
+     *
+     * @param variableId target variable ID
+     */
+    public List<Snapshot.Variable> dependsOnDeep(String variableId) {
+        return dependsOnDeep(variableId, Collections.emptySet());
+    }
+
+    /**
+     * Returns transitive dependencies of the given variable, stopping at variables in {@code stopVariables}.
+     *
+     * @param variableId    target variable ID
+     * @param stopVariables variable IDs at which traversal halts
+     */
+    public List<Snapshot.Variable> dependsOnDeep(String variableId, Set<String> stopVariables) {
+        if (stopVariables.contains(variableId)) {
+            return Collections.emptyList();
+        }
+        final var producedByOperation = producedBy(variableId);
+        if (producedByOperation.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<String, Snapshot.Variable> result = new HashMap<>();
+        producedByOperation.ifPresent(operation -> {
+            operation.arguments()
+                    .stream()
+                    .map(WrappedArgumentId::variableId)
+                    .map(Object::toString)
+                    .map(this::getVariable)
+                    .forEach(variable -> {
+                        result.put(variable.track().getId(), variable);
+                        dependsOnDeep(variable.track().getId(), stopVariables)
+                                .forEach(v -> result.put(v.track().getId(), v));
+                    });
+        });
+        return result.values().stream().toList();
+    }
+
+    /**
+     * Extracts the minimal sub-graph required to reproduce the given variable as a new {@link Snapshot}.
+     * The result includes the variable itself, all its ancestral operations, and all their input variables,
+     * sorted by numeric ID.
+     *
+     * @param variableId    target variable ID
+     * @param stopVariables variable IDs at which backward traversal halts
+     */
+    public Snapshot cpgOf(String variableId, Set<String> stopVariables) {
+        final var ops = new ArrayList<>(producedByDeep(variableId, stopVariables));
+        final var variables = new ArrayList<>(dependsOnDeep(variableId, stopVariables));
+        variables.add(getVariable(variableId));
+
+        ops.sort((o1, o2) -> Integer.compare(o1.track().getNumericId(), o2.track().getNumericId()));
+        variables.sort((v1, v2) -> Integer.compare(v1.track().getNumericId(), v2.track().getNumericId()));
+        return new Snapshot(Descriptor.descriptor("CPG for variable " + variableId), variables, ops);
+    }
+
+    /**
+     * Looks up a variable by ID.
+     *
+     * @param variableId variable ID
+     * @return the variable, or empty if not found
+     */
+    public Optional<Snapshot.Variable> variable(String variableId) {
+        return Optional.ofNullable(variables.get(variableId));
+    }
+
+    /**
+     * Looks up an operation by ID.
+     *
+     * @param operationId operation ID
+     * @return the operation, or empty if not found
+     */
+    public Optional<Snapshot.Operation> operation(String operationId) {
+        return Optional.ofNullable(operations.get(operationId));
+    }
+
+    /**
+     * Returns the underlying snapshot.
+     */
+    public Snapshot getSnapshot() {
+        return snapshot;
+    }
+
+    private Snapshot.Variable getVariable(String variableId) {
+        final var variable = variables.get(variableId);
+        if (variable == null) {
+            throw new IllegalArgumentException("Variable is not found: " + variableId);
+        }
+        return variable;
+    }
+
+    public List<Snapshot.Variable> findVariables(Predicate<Snapshot.Variable> predicate) {
+        return variables.values().stream().filter(predicate).toList();
+    }
+
+    /**
+     * @param predicate
+     * @return null if not found
+     * @throws IllegalStateException if more than one result is found
+     */
+    public Snapshot.Variable findSingleVariable(Predicate<Snapshot.Variable> predicate) {
+        final var results = findVariables(predicate);
+        if (results.isEmpty()) {
+            return null;
+        }
+        if (results.size() > 1) {
+            throw new IllegalStateException("Expected a single result, but found " + results.size());
+        }
+        return results.get(0);
+    }
+
+    public Snapshot.Variable findSingleVariable(String name) {
+        return findSingleVariable(it -> it.track().getDescriptor().getName().equals(name));
+    }
+
+    public List<Snapshot.Variable> findVariables(String name) {
+        return findVariables(it -> it.track().getDescriptor().getName().equals(name));
+    }
+
+    public List<Snapshot.Variable> variables() {
+        return snapshot.variables();
+    }
+
+    public List<Snapshot.Operation> operations() {
+        return snapshot.operations();
+    }
+}

--- a/src/test/java/io/compprov/tools/SnapshotNavigatorTest.java
+++ b/src/test/java/io/compprov/tools/SnapshotNavigatorTest.java
@@ -1,0 +1,330 @@
+package io.compprov.tools;
+
+import io.compprov.core.DefaultComputationEnvironment;
+import io.compprov.core.Snapshot;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * Graph: snapshots/metrology.json — gauge-block interferometry / refractometry
+ * 96 variables (40 INPUT, 56 OUTPUT), 56 operations.
+ *
+ * Notable properties exercised by these tests:
+ *  - i_1 (computation precision) is the mc argument in every operation
+ *  - i_4, i_5 (unused wavelengths) are never referenced in any op → leaves + unused inputs
+ *  - o_96 (deltaL) is the only OUTPUT leaf (the final measurement result)
+ *  - op_2 squares o_12: multiply(o_12, o_12) — same variable used twice in one op
+ *  - o_96 depends transitively on all 56 operations
+ */
+class SnapshotNavigatorTest {
+
+    private static Snapshot snapshot;
+    private static SnapshotNavigator nav;
+    private static DefaultComputationEnvironment env;
+
+    @BeforeAll
+    static void setup() throws IOException {
+        env = DefaultComputationEnvironment.create();
+        byte[] json = SnapshotNavigatorTest.class
+                .getResourceAsStream("/snapshots/metrology.json")
+                .readAllBytes();
+        snapshot = env.fromJson(json);
+        nav = new SnapshotNavigator(snapshot);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static Set<String> varIds(List<Snapshot.Variable> vars) {
+        return vars.stream().map(v -> v.track().getId()).collect(Collectors.toSet());
+    }
+
+    private static Set<String> opIds(List<Snapshot.Operation> ops) {
+        return ops.stream().map(o -> o.track().getId()).collect(Collectors.toSet());
+    }
+
+    // ── getSnapshot ──────────────────────────────────────────────────────────
+
+    @Test
+    void getSnapshot_returnsSameInstance() {
+        assertSame(snapshot, nav.getSnapshot());
+    }
+
+    // ── variable / operation lookup ──────────────────────────────────────────
+
+    @Test
+    void variable_knownId_returnsVariable() {
+        var result = nav.variable("i_1");
+        assertTrue(result.isPresent());
+        assertEquals("i_1", result.get().track().getId());
+    }
+
+    @Test
+    void variable_unknownId_returnsEmpty() {
+        assertTrue(nav.variable("nonexistent").isEmpty());
+    }
+
+    @Test
+    void operation_knownId_returnsOperation() {
+        var result = nav.operation("op_1");
+        assertTrue(result.isPresent());
+        assertEquals("op_1", result.get().track().getId());
+    }
+
+    @Test
+    void operation_unknownId_returnsEmpty() {
+        assertTrue(nav.operation("nonexistent").isEmpty());
+    }
+
+    // ── leaves ───────────────────────────────────────────────────────────────
+
+    @Test
+    void leaves_unusedInputsAndFinalOutput() {
+        // i_4 and i_5 are INPUT variables never referenced in any operation
+        // o_96 (deltaL) is the final computed result, not consumed by any operation
+        assertEquals(Set.of("i_4", "i_5", "o_96"), varIds(nav.leaves()));
+    }
+
+    // ── inputs ───────────────────────────────────────────────────────────────
+
+    @Test
+    void inputs_countAndSpotCheck() {
+        List<Snapshot.Variable> inputs = nav.roots();
+        assertEquals(40, inputs.size());
+        Set<String> ids = varIds(inputs);
+        assertTrue(ids.containsAll(Set.of("i_1", "i_4", "i_5", "i_7", "i_95")));
+    }
+
+    // ── unused ───────────────────────────────────────────────────────────────
+
+    @Test
+    void unused_twoUnconsumedInputVariables() {
+        // i_4 (lambda_vac1) and i_5 (lambda_vac2) are present but never consumed
+        assertEquals(Set.of("i_4", "i_5"), varIds(nav.unused()));
+    }
+
+    // ── produces ─────────────────────────────────────────────────────────────
+
+    @Test
+    void produces_unusedInput_returnsEmpty() {
+        assertTrue(nav.produces("i_4").isEmpty());
+    }
+
+    @Test
+    void produces_variableWithTwoConsumers() {
+        // i_6 (HeNe wavelength) consumed by op_10 (→ o_26) and op_48 (→ o_82)
+        assertEquals(Set.of("o_26", "o_82"), varIds(nav.produces("i_6")));
+    }
+
+    @Test
+    void produces_universalMcParameter_mostOutputVariables() {
+        // i_1 is the mc argument in 55 of the 56 operations (op_9/Exp_double has no mc arg)
+        assertEquals(55, varIds(nav.produces("i_1")).size());
+    }
+
+    @Test
+    void produces_intermediateVariable_singleDownstream() {
+        // o_23 (Wexler exponent) consumed by op_9 only → o_24 (svp)
+        assertEquals(Set.of("o_24"), varIds(nav.produces("o_23")));
+    }
+
+    @Test
+    void produces_leaf_returnsEmpty() {
+        assertTrue(nav.produces("o_96").isEmpty());
+    }
+
+    // ── producedBy ───────────────────────────────────────────────────────────
+
+    @Test
+    void producedBy_outputVariable_returnsProducingOp() {
+        var result = nav.producedBy("o_12");
+        assertTrue(result.isPresent());
+        assertEquals("op_1", result.get().track().getId());
+    }
+
+    @Test
+    void producedBy_inputVariable_returnsEmpty() {
+        assertTrue(nav.producedBy("i_7").isEmpty());
+    }
+
+    // ── dependsOn ────────────────────────────────────────────────────────────
+
+    @Test
+    void dependsOn_returnsDirectArgumentsOfProducingOp() {
+        // op_1: add(a=i_7, b=i_11, mc=i_1) → o_12
+        assertEquals(Set.of("i_7", "i_11", "i_1"), varIds(nav.dependsOn("o_12")));
+    }
+
+    @Test
+    void dependsOn_deduplicatesSameVariableUsedTwice() {
+        // op_2: multiply(a=o_12, b=o_12, mc=i_1) → o_13 — same variable in both arguments
+        // .distinct() must collapse it to a single entry
+        assertEquals(Set.of("o_12", "i_1"), varIds(nav.dependsOn("o_13")));
+    }
+
+    @Test
+    void dependsOn_finalOutput_directArgsOnly() {
+        // op_56: subtract(a=o_94, b=i_95, mc=i_1) → o_96
+        assertEquals(Set.of("o_94", "i_95", "i_1"), varIds(nav.dependsOn("o_96")));
+    }
+
+    @Test
+    void dependsOn_inputVariable_returnsEmpty() {
+        assertTrue(nav.dependsOn("i_4").isEmpty());
+    }
+
+    // ── producesDeep ─────────────────────────────────────────────────────────
+
+    @Test
+    void producesDeep_unusedInput_returnsEmpty() {
+        assertTrue(nav.producesDeep("i_4").isEmpty());
+    }
+
+    @Test
+    void producesDeep_inputConsumedByFinalOpOnly() {
+        // i_95 (L_nom) only consumed by op_56 → o_96 (leaf)
+        assertEquals(Set.of("o_96"), varIds(nav.producesDeep("i_95")));
+    }
+
+    @Test
+    void producesDeep_transitivelyReachesFinalOutput() {
+        // i_11 (Kelvin offset) → o_12 → ... → o_96; both direct hop and final output present
+        Set<String> result = varIds(nav.producesDeep("i_11"));
+        assertTrue(result.contains("o_12"), "must include direct first hop");
+        assertTrue(result.contains("o_96"), "must reach final output");
+        assertFalse(result.contains("o_86"), "o_86 is only reachable via i_84/i_85, not from i_11");
+    }
+
+    @Test
+    void producesDeep_withStop_haltAtStopVariable() {
+        // o_12 should appear in result (stop does not exclude the boundary itself),
+        // but nothing downstream of o_12 should be traversed
+        Set<String> result = varIds(nav.producesDeep("i_11", Set.of("o_12")));
+        assertTrue(result.contains("o_12"), "stop variable itself must be included");
+        assertFalse(result.contains("o_96"), "downstream of stop must not appear");
+    }
+
+    // ── producedByDeep ───────────────────────────────────────────────────────
+
+    @Test
+    void producedByDeep_singleHopVariable() {
+        // o_12 produced by op_1 only; its args (i_7, i_11, i_1) are all inputs
+        assertEquals(Set.of("op_1"), opIds(nav.producedByDeep("o_12")));
+    }
+
+    @Test
+    void producedByDeep_inputVariable_returnsEmpty() {
+        assertTrue(nav.producedByDeep("i_7").isEmpty());
+    }
+
+    @Test
+    void producedByDeep_finalOutput_allOpsInAncestry() {
+        // o_96 is the result of a calculation that uses every single operation
+        assertEquals(56, nav.producedByDeep("o_96").size());
+    }
+
+    @Test
+    void producedByDeep_withStop_limitsAncestryToTopOp() {
+        // Stopping at o_94 cuts the entire production chain — only the last op survives
+        // op_56: subtract(o_94, i_95, mc=i_1) → o_96
+        assertEquals(Set.of("op_56"), opIds(nav.producedByDeep("o_96", Set.of("o_94"))));
+    }
+
+    // ── dependsOnDeep ────────────────────────────────────────────────────────
+
+    @Test
+    void dependsOnDeep_singleHop_directInputsOnly() {
+        // o_12 depends on i_7, i_11, i_1 — all are inputs with no further deps
+        assertEquals(Set.of("i_7", "i_11", "i_1"), varIds(nav.dependsOnDeep("o_12")));
+    }
+
+    @Test
+    void dependsOnDeep_inputVariable_returnsEmpty() {
+        assertTrue(nav.dependsOnDeep("i_7").isEmpty());
+    }
+
+    @Test
+    void dependsOnDeep_finalOutput_fullAncestryExcludingUnusedInputs() {
+        // 38 used inputs (40 total − i_4 − i_5) + 55 intermediate outputs (56 total − o_96) = 93
+        Set<String> result = varIds(nav.dependsOnDeep("o_96"));
+        assertEquals(93, result.size());
+        assertFalse(result.contains("i_4"), "i_4 is unused — not reachable by any operation");
+        assertFalse(result.contains("i_5"), "i_5 is unused — not reachable by any operation");
+        assertFalse(result.contains("o_96"), "a variable cannot depend on itself");
+        assertTrue(result.contains("i_7"),  "T_air feeds the refractivity chain");
+        assertTrue(result.contains("i_1"),  "mc parameter used by all ops");
+    }
+
+    @Test
+    void dependsOnDeep_withStop_haltAtBoundaryVariables() {
+        // Stopping at o_61 (dry-air refractivity) and o_78 (water-vapor refractivity):
+        // those two boundary variables must still appear in the result,
+        // but i_7 (T_air), which is only reachable through the sub-chain behind them, must not
+        Set<String> result = varIds(nav.dependsOnDeep("o_96", Set.of("o_61", "o_78")));
+        assertTrue(result.contains("o_61"), "boundary variable must be included");
+        assertTrue(result.contains("o_78"), "boundary variable must be included");
+        assertFalse(result.contains("i_7"), "T_air is only reachable past the stop boundary");
+    }
+
+    // ── cpgOf ────────────────────────────────────────────────────────────────
+
+    @Test
+    void cpgOf_singleOperation_exactContents() {
+        // o_12 (T_K) produced by op_1(i_7, i_11, mc=i_1)
+        Snapshot sub = nav.cpgOf("o_12", Set.of());
+        assertEquals(Set.of("i_1", "i_7", "i_11", "o_12"), varIds(sub.variables()));
+        assertEquals(Set.of("op_1"), opIds(sub.operations()));
+    }
+
+    @Test
+    void cpgOf_finalOutput_fullGraphWithoutUnusedInputs() {
+        // 94 variables: all 96 minus the two unused inputs (i_4, i_5)
+        Snapshot sub = nav.cpgOf("o_96", Set.of());
+        assertEquals(94, sub.variables().size());
+        assertEquals(56, sub.operations().size());
+    }
+
+    @Test
+    void cpgOf_withStop_retainsOnlyTopLayer() {
+        // Stopping at o_94: only the final subtraction op survives
+        Snapshot sub = nav.cpgOf("o_96", Set.of("o_94"));
+        assertEquals(Set.of("o_94", "i_95", "i_1", "o_96"), varIds(sub.variables()));
+        assertEquals(Set.of("op_56"), opIds(sub.operations()));
+    }
+
+    @Test
+    void cpgOf_variablesSortedByNumericId() {
+        List<Integer> ids = nav.cpgOf("o_96", Set.of()).variables().stream()
+                .map(v -> v.track().getNumericId())
+                .toList();
+        for (int i = 1; i < ids.size(); i++) {
+            assertTrue(ids.get(i - 1) < ids.get(i), "variables not sorted at index " + i);
+        }
+    }
+
+    @Test
+    void cpgOf_operationsSortedByNumericId() {
+        List<Integer> ids = nav.cpgOf("o_96", Set.of()).operations().stream()
+                .map(o -> o.track().getNumericId())
+                .toList();
+        for (int i = 1; i < ids.size(); i++) {
+            assertTrue(ids.get(i - 1) < ids.get(i), "operations not sorted at index " + i);
+        }
+    }
+
+    @Test
+    void usageExample() {
+        final var ciddorVar = nav.findSingleVariable(v->v.track().getDescriptor().getName().contains("Ciddor"));
+        final var thermallyCorrectdLenVar = nav.findSingleVariable(v->v.track().getDescriptor().getName().contains("thermally corrected"));
+        final var subgraph = nav.cpgOf(thermallyCorrectdLenVar.track().getId(), Set.of(ciddorVar.track().getId()));
+        assertEquals(8, subgraph.operations().size());
+        assertEquals(18, subgraph.variables().size());
+        System.out.println(env.toJson(subgraph));
+    }
+}


### PR DESCRIPTION
 * Add SnapshotNavigator for querying and traversing CPGs. Provides leaf/root/unused variable lookup, one-hop and transitive producer/dependency traversal, and cpgOf() for extracting minimal reproducible subgraphs from a Snapshot. 
 * Add EnvironmentCustomizer extension point and a registerWrapper() overload accepting a JacksonModule to support wrapper types with custom (de)serialization modules.